### PR TITLE
Fix docker registry markdown problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use this as base for your own containers:
 
 ```dockerfile
 FROM mini/base
+
 RUN apk-install <packagename>
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
It looks like the docker registry markdown converter doesn't convert the usage example properly. `FROM` and `USE` are on the same line at https://registry.hub.docker.com/u/mini/base/. I've reported the problem at IRC but this change fixes it too. Feel free to close this and with for docker registry to fix the problem though.